### PR TITLE
Removing OSS Directives from 1609.2 ASN.1 Specification

### DIFF
--- a/1609dot2-P2P.asn
+++ b/1609dot2-P2P.asn
@@ -1,4 +1,3 @@
-
 IEEE1609dot2-Peer2Peer {iso(1) identified-organization(3) ieee(111) 
 standards-association-numbered-series-standards(2) wave-stds(1609)  
 dot2(2) management (2) peer-to-peer (1)}

--- a/crl-base-types.asn
+++ b/crl-base-types.asn
@@ -1,10 +1,3 @@
---<OSS.UNBOUNDED SEQUENCE OF>--
---<OSS.UNBOUNDED UTF8String>--
---<OSS.UNBOUNDED IA5String>--
---<OSS.UNBOUNDED OCTET STRING>--
---<OSS.UNBOUNDED BIT STRING>--
---<OSS.LONG>--
-
 IEEE1609dot2CrlBaseTypes {iso(1) identified-organization(3) ieee(111) 
 standards-association-numbered-series-standards(2) wave-stds(1609)  
 dot2(2) crl(3) base-types(1)}

--- a/crl-protocol.asn
+++ b/crl-protocol.asn
@@ -1,5 +1,3 @@
---<OSS.LONG>--
-
 IEEE1609dot2Crl {iso(1) identified-organization(3) ieee(111) 
 standards-association-numbered-series-standards(2) wave-stds(1609)  
 dot2(2) crl(3) protocol(2)}

--- a/crl-ssp.asn
+++ b/crl-ssp.asn
@@ -1,10 +1,3 @@
---<OSS.UNBOUNDED SEQUENCE OF>--
---<OSS.UNBOUNDED UTF8String>--
---<OSS.UNBOUNDED IA5String>--
---<OSS.UNBOUNDED OCTET STRING>--
---<OSS.UNBOUNDED BIT STRING>--
---<OSS.LONG>--
-
 IEEE1609dot2CrlSsp {iso(1) identified-organization(3) ieee(111) 
 standards-association-numbered-series-standards(2) wave-stds(1609)  
 dot2(2) crl(3) service-specific-permissions (3)}

--- a/wsa-ssp.asn
+++ b/wsa-ssp.asn
@@ -1,4 +1,3 @@
-
 IEEE1609dot2WsaSsp {iso(1) identified-organization(3) ieee(111) 
 standards-association-numbered-series-standards(2) wave-stds(1609)  
 dot2(2) wsa(4) ssp(2)}


### PR DESCRIPTION
Some of the ASN.1 directives are causing warnings in downstream projects because they are not supported by OSS' ASN.1 Studio.

I've removed the OSS directives and have achieved compilation with 0 errors and 0 warnings using ASN.1 Studio 7.1 on Kubuntu 14.04LTS.